### PR TITLE
Updated home.html http -> https

### DIFF
--- a/home.html
+++ b/home.html
@@ -18,8 +18,8 @@
 
     <!-- Custom Google Web Font -->
     <link href="font-awesome/css/font-awesome.min.css" rel="stylesheet">
-    <link href='http://fonts.googleapis.com/css?family=Lato:100,300,400,700,900,100italic,300italic,400italic,700italic,900italic' rel='stylesheet' type='text/css'>
-	<link href='http://fonts.googleapis.com/css?family=Arvo:400,700' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900,100italic,300italic,400italic,700italic,900italic' rel='stylesheet' type='text/css'>
+	<link href='https://fonts.googleapis.com/css?family=Arvo:400,700' rel='stylesheet' type='text/css'>
 
     <!-- Custom CSS-->
     <link href="css/general.css" rel="stylesheet">
@@ -547,6 +547,7 @@
             <h3 class="footer-title">Follow Me!</h3>
             <p>Vuoi ricevere news su altri template?<br/>
               Visita Andrea Galanti.it e vedrai tutte le news riguardanti nuovi Theme!<br/>
+	      <!--Hierdurch funktioniert die ssl-zertifizierung nicht. Wir brauchen hier einen https link-->
               Go to: <a  href="http://andreagalanti.it" target="_blank">andreagalanti.it</a>
             </p>
 


### PR DESCRIPTION
Für die SSL-Zertifizierung müssen alle Links auf https verlinkt sein und nicht auf http. Dabei konnte ich das Meiste ändern, aber siehe Zeile 550.